### PR TITLE
Fix for tags matcher

### DIFF
--- a/lettuce/core.py
+++ b/lettuce/core.py
@@ -655,8 +655,10 @@ class Scenario(object):
         matched = []
 
         if isinstance(self.tags, list):
+            positive_tags = [tag for tag in tags if not tag.startswith('-') and not tag.startswith('~')]
+
             for tag in self.tags:
-                if tag in tags:
+                if tag in positive_tags:
                     return True
         else:
             self.tags = []

--- a/lettuce/core.py
+++ b/lettuce/core.py
@@ -654,12 +654,7 @@ class Scenario(object):
 
         matched = []
 
-        if isinstance(self.tags, list) and not has_exclusionary_tags:
-
-            for tag in self.tags:
-                if tag in tags:
-                    return True
-        else:
+        if not isinstance(self.tags, list):
             self.tags = []
 
         for tag in tags:

--- a/lettuce/core.py
+++ b/lettuce/core.py
@@ -654,11 +654,10 @@ class Scenario(object):
 
         matched = []
 
-        if isinstance(self.tags, list):
-            positive_tags = [tag for tag in tags if not tag.startswith('-') and not tag.startswith('~')]
+        if isinstance(self.tags, list) and not has_exclusionary_tags:
 
             for tag in self.tags:
-                if tag in positive_tags:
+                if tag in tags:
                     return True
         else:
             self.tags = []

--- a/lettuce/core.py
+++ b/lettuce/core.py
@@ -666,7 +666,6 @@ class Scenario(object):
             if fuzzable:
                 tag = tag[1:]
 
-            result = tag in self.tags
             if fuzzable:
                 fuzzed = []
                 for internal_tag in self.tags:
@@ -677,10 +676,12 @@ class Scenario(object):
                         fuzzed.append(ratio > 80)
 
                 result = any(fuzzed)
+                matched.append(result)
             elif exclude:
                 result = tag not in self.tags
-
-            matched.append(result)
+                matched.append(result)
+            elif tag in self.tags:
+                matched.append(True)
 
         return all(matched)
 


### PR DESCRIPTION
Lettuce is actually ignoring negative cases in case of a job has more than one tag.
It is basically directly doing a return True in case of a positive, and ignoring all the exclusionary ones.

This simple line fixes it.

How to reproduce issue:
```
self.tags is
[u'guest', u'behave']
```
and tags is: 
```
['-behave', 'guest']
```
What will happen right now is that lettuce will match guest and will run the scenario, but it will ignore the -behave that should have removed that scenario.
